### PR TITLE
use fms as a package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,11 @@ include( fms_compiler_flags )
 include_directories( ${FMS_INCLUDE_DIRS} ${FMS_EXTRA_INCLUDE_DIRS} )
 
 ################################################################################
+list( APPEND fms_hdr_files
+include/file_version.h
+include/fms_platform.h
+)
+
 list( APPEND fms_src_files
 amip_interp/amip_interp.F90
 astronomy/astronomy.F90
@@ -158,8 +163,6 @@ horiz_interp/horiz_interp_conserve.F90
 horiz_interp/horiz_interp_spherical.F90
 horiz_interp/horiz_interp_type.F90
 horiz_interp/test_horiz_interp.F90
-include/file_version.h
-include/fms_platform.h
 interpolator/interpolator.F90
 memutils/memuse.c
 memutils/memutils.F90
@@ -301,11 +304,16 @@ tridiagonal/tridiagonal.F90
 
 ################################################################################
 ecbuild_add_library( TARGET   fms
-                     SOURCES  ${fms_src_files}
+                     SOURCES  ${fms_hdr_files} ${fms_src_files}
                      LIBS     ${NETCDF_LIBRARIES}
+                     INSTALL_HEADERS_LIST ${fms_hdr_files}
                      LINKER_LANGUAGE ${FMS_LINKER_LANGUAGE}
                     )
 ################################################################################
+
+if(ECBUILD_INSTALL_FORTRAN_MODULES)
+  install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/${CMAKE_CFG_INTDIR} DESTINATION ${INSTALL_INCLUDE_DIR} )
+endif()
 
 ################################################################################
 # Finalise configuration


### PR DESCRIPTION
Allows building FMS as a standalone package.
This will become necessary  when using FMS with FV3, SOCA, Coupled, GEOS and GFS
Works with `fv3-bundle`, `mom6-bundle` and `soca-bundle`

`fv3-jedi-lm` and `fv3-jedi` can have the line
`ecbuild_use_package(PROJECT fms REQUIRED)`


Change-Id: Ieedfa84a101e7695f5b1e3c58d3c1adeb67a66a9