### PR TITLE
Bugfix/mpp update ad

### DIFF
--- a/mpp/include/mpp_do_update_ad.h
+++ b/mpp/include/mpp_do_update_ad.h
@@ -176,16 +176,7 @@
                tMe = overPtr%tileMe(n)
                is = overPtr%is(n); ie = overPtr%ie(n)
                js = overPtr%js(n); je = overPtr%je(n)
-               select case( overPtr%rotation(n) )
-               case(ZERO)
-                  pos = pos + (ie-is+1)*(je-js+1)*ke*l_size
-               case( MINUS_NINETY )
-                  pos = pos + (ie-is+1)*(je-js+1)*ke*l_size
-               case( NINETY )
-                  pos = pos + (ie-is+1)*(je-js+1)*ke*l_size
-               case( ONE_HUNDRED_EIGHTY )
-                  pos = pos + (ie-is+1)*(je-js+1)*ke*l_size
-               end select
+               pos = pos + (ie-is+1)*(je-js+1)*ke*l_size
             endif
          end do ! do n = 1, overPtr%count
 

--- a/mpp/include/mpp_do_update_ad.h
+++ b/mpp/include/mpp_do_update_ad.h
@@ -277,7 +277,7 @@
 
       !----------------------------------------------------------------------
       buffer_pos = buffer_recv_size
-      call  mpp_clock_begin(unpack_clock)
+      call  mpp_clock_begin(unpk_clock)
       do m = 1, update%nsend
          send_msgsize(m) = 0
          overPtr => update%send(m)
@@ -359,7 +359,7 @@
          send_msgsize(m) = pos-buffer_pos
          buffer_pos = pos
       end do ! end do m = 1, nsend
-      call mpp_clock_end(unpack_clock)
+      call mpp_clock_end(unpk_clock)
 
       call mpp_clock_begin(wait_clock)
       call mpp_sync_self()

--- a/mpp/include/mpp_do_update_ad.h
+++ b/mpp/include/mpp_do_update_ad.h
@@ -128,8 +128,7 @@
                           //trim(domain%name)
          deallocate(msg1, msg2, msg3)
       endif
-
-      
+   
       !----------------------------------------------------------------------
       buffer_pos = 0
       do m = 1, update%nrecv
@@ -153,7 +152,8 @@
       buffer_recv_size = buffer_pos
       send_start_pos = buffer_pos
 
-      ! send info-----------------------------------------------
+      ! send info
+      !----------------------------------------------------------------------
       buffer_pos = buffer_recv_size 
       ! pack
       do m = 1, update%nsend
@@ -193,10 +193,11 @@
          buffer_pos = pos
       end do ! end do m = 1, nsend
  
-      !backward communication starts here---------------------
-
+      !backward communication
+      !----------------------------------------------------------------------
       !recv
       buffer_pos = buffer_recv_size
+      call  mpp_clock_begin(pack_clock)
       do m = update%nrecv, 1, -1
          overPtr => update%recv(m)
          if( overPtr%count == 0 )cycle
@@ -224,11 +225,11 @@
             endif
          end do ! do n = 1, overPtr%count
       end do
+      call mpp_clock_end(pack_clock)
 
-      !--------------------------------------------------------
-
+      !----------------------------------------------------------------------
       buffer_pos = send_start_pos
-      call mpp_clock_begin(send_clock)
+      call mpp_clock_begin(recv_clock)
       do m = 1, update%nsend
          msgsize = send_msgsize(m)
          if(msgsize == 0) cycle
@@ -236,13 +237,12 @@
          call mpp_recv( buffer(buffer_pos+1), glen=msgsize, from_pe=to_pe, block=.FALSE., tag=COMM_TAG_2 )
          buffer_pos = buffer_pos + msgsize
       end do ! end do ist = 0,nlist-1
-      call mpp_clock_end(send_clock)
+      call mpp_clock_end(recv_clock)
 
-     !--------------------------------------------------------
-
+      !----------------------------------------------------------------------
       !recv
       buffer_pos = 0
-      call mpp_clock_begin(recv_clock)
+      call mpp_clock_begin(send_clock)
       do m = 1, update%nrecv
          overPtr => update%recv(m)
          if( overPtr%count == 0 )cycle
@@ -269,13 +269,15 @@
             buffer_pos = buffer_pos + msgsize
          end if
       end do ! end do m = 1, update%nrecv
-      call mpp_clock_end(recv_clock)
+      call mpp_clock_end(send_clock)
 
+      call mpp_clock_begin(wait_clock)
       call mpp_sync_self(check=EVENT_RECV)
-     !--------------------------------------------------------
+      call mpp_clock_end(wait_clock)
 
+      !----------------------------------------------------------------------
       buffer_pos = buffer_recv_size
-      call  mpp_clock_begin(pack_clock)
+      call  mpp_clock_begin(unpack_clock)
       do m = 1, update%nsend
          send_msgsize(m) = 0
          overPtr => update%send(m)
@@ -357,10 +359,11 @@
          send_msgsize(m) = pos-buffer_pos
          buffer_pos = pos
       end do ! end do m = 1, nsend
-      call mpp_clock_end(pack_clock)
+      call mpp_clock_end(unpack_clock)
 
-
+      call mpp_clock_begin(wait_clock)
       call mpp_sync_self()
+      call mpp_clock_end(wait_clock)
 
       return
     end subroutine MPP_DO_UPDATE_AD_3D_

--- a/mpp/include/mpp_do_update_ad.h
+++ b/mpp/include/mpp_do_update_ad.h
@@ -42,16 +42,15 @@
      
 !receive domains saved here for unpacking
 !for non-blocking version, could be recomputed
-      integer,    allocatable :: msg1(:), msg2(:)
+      integer,    allocatable :: msg1(:), msg2(:), msg3(:)
       logical :: send(8), recv(8), update_edge_only
-      integer :: to_pe, from_pe, pos, msgsize, msgsize_send
+      integer :: to_pe, from_pe, pos, msgsize
       integer :: n, l_size, l, m, i, j, k
       integer :: is, ie, js, je, tMe, dir
       integer :: start, start1, start2, index, is1, ie1, js1, je1, ni, nj, total
       integer :: buffer_recv_size, nlist, outunit
       integer :: send_start_pos
       integer :: send_msgsize(MAXLIST)
-
 
       outunit = stdout()
       ptr = LOC(mpp_domains_stack)
@@ -82,9 +81,10 @@
 
       if(debug_message_passing) then
          nlist = size(domain%list(:))  
-         allocate(msg1(0:nlist-1), msg2(0:nlist-1) )
+         allocate(msg1(0:nlist-1), msg2(0:nlist-1), msg3(0:nlist-1) )
          msg1 = 0
          msg2 = 0
+         msg3 = 0
          do m = 1, update%nrecv
             overPtr => update%recv(m)
             msgsize = 0
@@ -98,7 +98,6 @@
             end do
             from_pe = update%recv(m)%pe
             l = from_pe-mpp_root_pe()
-            call mpp_recv( msg1(l), glen=1, from_pe=from_pe, block=.FALSE., tag=COMM_TAG_1 )
             msg2(l) = msgsize
          enddo
 
@@ -113,9 +112,10 @@
                   msgsize = msgsize + (ie-is+1)*(je-js+1)
                end if
             end do
-            call mpp_send( msgsize, plen=1, to_pe=overPtr%pe, tag=COMM_TAG_1 )
+            l = overPtr%pe - mpp_root_pe()
+            msg3(l) = msgsize
          enddo
-         call mpp_sync_self(check=EVENT_RECV)
+         call mpp_alltoall(msg3, 1, msg1, 1)
 
          do m = 0, nlist-1
             if(msg1(m) .NE. msg2(m)) then
@@ -124,14 +124,14 @@
                call mpp_error(FATAL, "mpp_do_update: mismatch on send and recv size")
             endif
          enddo
-         call mpp_sync_self()
          write(outunit,*)"NOTE from mpp_do_update: message sizes are matched between send and recv for domain " &
                           //trim(domain%name)
-         deallocate(msg1, msg2)
+         deallocate(msg1, msg2, msg3)
       endif
 
-      !recv
-      buffer_pos = 0  
+      
+      !----------------------------------------------------------------------
+      buffer_pos = 0
       do m = 1, update%nrecv
          overPtr => update%recv(m)
          if( overPtr%count == 0 )cycle
@@ -139,38 +139,25 @@
          do n = 1, overPtr%count
             dir = overPtr%dir(n)
             if(recv(dir)) then
-               tMe = overPtr%tileMe(n)
                is = overPtr%is(n); ie = overPtr%ie(n)
                js = overPtr%js(n); je = overPtr%je(n)
                msgsize = msgsize + (ie-is+1)*(je-js+1)
-               msgsize_send = (ie-is+1)*(je-js+1)*ke*l_size
-               pos = buffer_pos + msgsize_send
-               do l=1,l_size  ! loop over number of fields
-                  ptr_field = f_addrs(l, tMe)
-                  do k = ke,1,-1
-                     do j = je, js, -1
-                        do i = ie, is, -1
-                           buffer(pos) = field(i,j,k)
-                           field(i,j,k) = 0.
-                           pos = pos - 1
-                        end do
-                     end do
-                  end do
-               end do
             end if
          end do
 
          msgsize = msgsize*ke*l_size
          if( msgsize.GT.0 )then
-            to_pe = overPtr%pe
-            call mpp_send( buffer(buffer_pos+1), plen=msgsize, to_pe=to_pe, tag=COMM_TAG_2 )
             buffer_pos = buffer_pos + msgsize
          end if
       end do ! end do m = 1, update%nrecv
       buffer_recv_size = buffer_pos
+      send_start_pos = buffer_pos
 
-      ! send
+      ! send info-----------------------------------------------
+      buffer_pos = buffer_recv_size 
+      ! pack
       do m = 1, update%nsend
+         send_msgsize(m) = 0
          overPtr => update%send(m)
          if( overPtr%count == 0 )cycle
          pos = buffer_pos
@@ -181,19 +168,116 @@
          enddo
          if( msgsize.GT.0 )then
             msgsize = msgsize*ke*l_size
-            msgsize_send = msgsize
+         end if
+
+         do n = 1, overPtr%count
+            dir = overPtr%dir(n)
+            if( send(dir) ) then
+               tMe = overPtr%tileMe(n)
+               is = overPtr%is(n); ie = overPtr%ie(n)
+               js = overPtr%js(n); je = overPtr%je(n)
+               select case( overPtr%rotation(n) )
+               case(ZERO)
+                  pos = pos + (ie-is+1)*(je-js+1)*ke*l_size
+               case( MINUS_NINETY )
+                  pos = pos + (ie-is+1)*(je-js+1)*ke*l_size
+               case( NINETY )
+                  pos = pos + (ie-is+1)*(je-js+1)*ke*l_size
+               case( ONE_HUNDRED_EIGHTY )
+                  pos = pos + (ie-is+1)*(je-js+1)*ke*l_size
+               end select
+            endif
+         end do ! do n = 1, overPtr%count
+
+         send_msgsize(m) = pos-buffer_pos
+         buffer_pos = pos
+      end do ! end do m = 1, nsend
+ 
+      !backward communication starts here---------------------
+
+      !recv
+      buffer_pos = buffer_recv_size
+      do m = update%nrecv, 1, -1
+         overPtr => update%recv(m)
+         if( overPtr%count == 0 )cycle
+         pos = buffer_pos
+         do n = overPtr%count, 1, -1
+            dir = overPtr%dir(n)
+            if( recv(dir) ) then
+               tMe = overPtr%tileMe(n)
+               is = overPtr%is(n); ie = overPtr%ie(n)
+               js = overPtr%js(n); je = overPtr%je(n)
+               msgsize = (ie-is+1)*(je-js+1)*ke*l_size
+               pos = buffer_pos - msgsize
+               buffer_pos = pos
+               do l=1,l_size  ! loop over number of fields
+                  ptr_field = f_addrs(l, tMe)
+                  do k = 1,ke
+                     do j = js, je
+                        do i = is, ie
+                           pos = pos + 1
+                           buffer(pos) = field(i,j,k)
+                        end do
+                     end do
+                  end do
+               end do
+            endif
+         end do ! do n = 1, overPtr%count
+      end do
+
+      !--------------------------------------------------------
+
+      buffer_pos = send_start_pos
+      call mpp_clock_begin(send_clock)
+      do m = 1, update%nsend
+         msgsize = send_msgsize(m)
+         if(msgsize == 0) cycle
+         to_pe = update%send(m)%pe
+         call mpp_recv( buffer(buffer_pos+1), glen=msgsize, from_pe=to_pe, block=.FALSE., tag=COMM_TAG_2 )
+         buffer_pos = buffer_pos + msgsize
+      end do ! end do ist = 0,nlist-1
+      call mpp_clock_end(send_clock)
+
+     !--------------------------------------------------------
+
+      !recv
+      buffer_pos = 0
+      call mpp_clock_begin(recv_clock)
+      do m = 1, update%nrecv
+         overPtr => update%recv(m)
+         if( overPtr%count == 0 )cycle
+         msgsize = 0
+         do n = 1, overPtr%count
+            dir = overPtr%dir(n)
+            if(recv(dir)) then
+               is = overPtr%is(n); ie = overPtr%ie(n)
+               js = overPtr%js(n); je = overPtr%je(n)
+               msgsize = msgsize + (ie-is+1)*(je-js+1)
+            end if
+         end do
+
+         msgsize = msgsize*ke*l_size
+         if( msgsize.GT.0 )then
             from_pe = overPtr%pe
-            call mpp_recv( buffer(buffer_pos+1), glen=msgsize, from_pe=from_pe, block=.FALSE., tag=COMM_TAG_2 )
+            mpp_domains_stack_hwm = max( mpp_domains_stack_hwm, (buffer_pos+msgsize) )
+            if( mpp_domains_stack_hwm.GT.mpp_domains_stack_size )then
+               write( text,'(i8)' )mpp_domains_stack_hwm
+               call mpp_error( FATAL, 'MPP_DO_UPDATE: mpp_domains_stack overflow, '// &
+                    'call mpp_domains_set_stack_size('//trim(text)//') from all PEs.' )
+            end if
+            call mpp_send( buffer(buffer_pos+1), plen=msgsize, to_pe=from_pe, tag=COMM_TAG_2 )
             buffer_pos = buffer_pos + msgsize
          end if
-      end do ! end do ist = 0,nlist-1
+      end do ! end do m = 1, update%nrecv
+      call mpp_clock_end(recv_clock)
 
       call mpp_sync_self(check=EVENT_RECV)
+     !--------------------------------------------------------
 
       buffer_pos = buffer_recv_size
-
-      ! send
+      call  mpp_clock_begin(pack_clock)
       do m = 1, update%nsend
+         send_msgsize(m) = 0
          overPtr => update%send(m)
          if( overPtr%count == 0 )cycle
          pos = buffer_pos
@@ -203,7 +287,13 @@
             if( send(dir) )  msgsize = msgsize + overPtr%msgsize(n)
          enddo
          if( msgsize.GT.0 )then
-            buffer_pos = pos
+            msgsize = msgsize*ke*l_size
+            mpp_domains_stack_hwm = max( mpp_domains_stack_hwm, pos+msgsize )
+            if( mpp_domains_stack_hwm.GT.mpp_domains_stack_size )then
+               write( text,'(i8)' )mpp_domains_stack_hwm
+               call mpp_error( FATAL, 'MPP_START_UPDATE_DOMAINS: mpp_domains_stack overflow, ' // &
+                    'call mpp_domains_set_stack_size('//trim(text)//') from all PEs.')
+            end if
          end if
 
          do n = 1, overPtr%count
@@ -212,64 +302,63 @@
                tMe = overPtr%tileMe(n)
                is = overPtr%is(n); ie = overPtr%ie(n)
                js = overPtr%js(n); je = overPtr%je(n)
-                  select case( overPtr%rotation(n) )
-                  case(ZERO)
-                     do l=1,l_size  ! loop over number of fields
-                        ptr_field = f_addrs(l, tMe)
-                        do k = 1,ke  
-                           do j = js, je
-                              do i = is, ie
-                                 pos = pos + 1
-                                 field(i,j,k)=field(i,j,k)+buffer(pos)
-                              end do
-                           end do
-                        end do
-                     end do
-                  case( MINUS_NINETY ) 
-                     do l=1,l_size  ! loop over number of fields
-                        ptr_field = f_addrs(l, tMe)
-                        do k = 1,ke  
+               select case( overPtr%rotation(n) )
+               case(ZERO)
+                  do l=1,l_size  ! loop over number of fields
+                     ptr_field = f_addrs(l, tMe)
+                     do k = 1,ke  
+                        do j = js, je
                            do i = is, ie
-                              do j = je, js, -1
-                                 pos = pos + 1
-                                 field(i,j,k)=field(i,j,k)+buffer(pos)
-                              end do
+                              pos = pos + 1
+                              field(i,j,k)=field(i,j,k) + buffer(pos)
                            end do
                         end do
                      end do
-                  case( NINETY ) 
-                     do l=1,l_size  ! loop over number of fields
-                        ptr_field = f_addrs(l, tMe)
-                        do k = 1,ke  
-                           do i = ie, is, -1
-                              do j = js, je
-                                 pos = pos + 1
-                                 field(i,j,k)=field(i,j,k)+buffer(pos) 
-                              end do
-                           end do
-                        end do
-                     end do
-                  case( ONE_HUNDRED_EIGHTY ) 
-                     do l=1,l_size  ! loop over number of fields
-                        ptr_field = f_addrs(l, tMe)
-                        do k = 1,ke  
+                  end do
+               case( MINUS_NINETY ) 
+                  do l=1,l_size  ! loop over number of fields
+                     ptr_field = f_addrs(l, tMe)
+                     do k = 1,ke  
+                        do i = is, ie
                            do j = je, js, -1
-                              do i = ie, is, -1
-                                 pos = pos + 1
-                                 field(i,j,k)=field(i,j,k)+buffer(pos)
-                              end do
+                              pos = pos + 1
+                              field(i,j,k)=field(i,j,k) + buffer(pos)
                            end do
                         end do
                      end do
-                  end select
+                  end do
+               case( NINETY ) 
+                  do l=1,l_size  ! loop over number of fields
+                     ptr_field = f_addrs(l, tMe)
+                     do k = 1,ke  
+                        do i = ie, is, -1
+                           do j = js, je
+                              pos = pos + 1
+                              field(i,j,k)=field(i,j,k) + buffer(pos)
+                           end do
+                        end do
+                     end do
+                  end do
+               case( ONE_HUNDRED_EIGHTY ) 
+                  do l=1,l_size  ! loop over number of fields
+                     ptr_field = f_addrs(l, tMe)
+                     do k = 1,ke  
+                        do j = je, js, -1
+                           do i = ie, is, -1
+                              pos = pos + 1
+                              field(i,j,k)=field(i,j,k) + buffer(pos)
+                           end do
+                        end do
+                     end do
+                  end do
+               end select
             endif
          end do ! do n = 1, overPtr%count
+         send_msgsize(m) = pos-buffer_pos
+         buffer_pos = pos
+      end do ! end do m = 1, nsend
+      call mpp_clock_end(pack_clock)
 
-         msgsize = pos - buffer_pos
-         if( msgsize.GT.0 )then
-            buffer_pos = pos
-         end if
-      end do ! end do ist = 0,nlist-1
 
       call mpp_sync_self()
 

--- a/mpp/include/mpp_do_update_ad.h
+++ b/mpp/include/mpp_do_update_ad.h
@@ -188,7 +188,6 @@
       !----------------------------------------------------------------------
       !recv
       buffer_pos = buffer_recv_size
-      call  mpp_clock_begin(pack_clock)
       do m = update%nrecv, 1, -1
          overPtr => update%recv(m)
          if( overPtr%count == 0 )cycle
@@ -216,11 +215,9 @@
             endif
          end do ! do n = 1, overPtr%count
       end do
-      call mpp_clock_end(pack_clock)
 
       !----------------------------------------------------------------------
       buffer_pos = send_start_pos
-      call mpp_clock_begin(recv_clock)
       do m = 1, update%nsend
          msgsize = send_msgsize(m)
          if(msgsize == 0) cycle
@@ -228,12 +225,10 @@
          call mpp_recv( buffer(buffer_pos+1), glen=msgsize, from_pe=to_pe, block=.FALSE., tag=COMM_TAG_2 )
          buffer_pos = buffer_pos + msgsize
       end do ! end do ist = 0,nlist-1
-      call mpp_clock_end(recv_clock)
 
       !----------------------------------------------------------------------
       !recv
       buffer_pos = 0
-      call mpp_clock_begin(send_clock)
       do m = 1, update%nrecv
          overPtr => update%recv(m)
          if( overPtr%count == 0 )cycle
@@ -260,15 +255,11 @@
             buffer_pos = buffer_pos + msgsize
          end if
       end do ! end do m = 1, update%nrecv
-      call mpp_clock_end(send_clock)
 
-      call mpp_clock_begin(wait_clock)
       call mpp_sync_self(check=EVENT_RECV)
-      call mpp_clock_end(wait_clock)
 
       !----------------------------------------------------------------------
       buffer_pos = buffer_recv_size
-      call  mpp_clock_begin(unpk_clock)
       do m = 1, update%nsend
          send_msgsize(m) = 0
          overPtr => update%send(m)
@@ -350,11 +341,8 @@
          send_msgsize(m) = pos-buffer_pos
          buffer_pos = pos
       end do ! end do m = 1, nsend
-      call mpp_clock_end(unpk_clock)
 
-      call mpp_clock_begin(wait_clock)
       call mpp_sync_self()
-      call mpp_clock_end(wait_clock)
 
       return
     end subroutine MPP_DO_UPDATE_AD_3D_


### PR DESCRIPTION
Due to the grid/domain config difference between fv3 and mom6, the bufferization bug of mpp_do_update_ad has been addressed in this pr. All fields data points were traced back and secured for backward communication for adjoint operation. dot product and validation tests were done for soca and fv3.