### PR TITLE
Potential fixes for stringop overflows

### DIFF
--- a/field_manager/field_manager.F90
+++ b/field_manager/field_manager.F90
@@ -1193,7 +1193,7 @@ do i = 1, num_elem
   if (val_name(1:1) .eq. squote) then  !{
 
     if (val_name(length:length) .eq. squote) then
-      val_name = val_name(2:length-1)
+      val_name(:length) = val_name(2:length-1)
       val_type = string_type
     elseif (val_name(length:length) .eq. dquote) then
       call mpp_error(FATAL, trim(error_header) // ' Quotes do not match in ' // trim(val_name) //       &

--- a/interpolator/interpolator.F90
+++ b/interpolator/interpolator.F90
@@ -3723,8 +3723,8 @@ integer :: len
 
 len = len_trim(string)
 if (string(len:len) == CHAR(0)) len = len -1
-
-chomp = string(:len)
+chomp(:) = ' '
+chomp(:MIN(len,64)) = string(:len)
 
 end function chomp
 !


### PR DESCRIPTION
I'm not sure what's happening with these two functions that are producing stringop_overflows with gfortran.  Perhaps this is a bug in gfortran's warnings, as the original code should work according to the Fortran documentation I have read.  Since I'm not a Fortran expert, I'm adding this as a draft PR.

```
/home/mjo/work/bundles/fv3-bundle/fms/interpolator/interpolator.F90:3727:0:

 3727 | chomp = string(:MIN(len,64))
      | 
Warning: ‘__builtin_memcpy’ reading 64 bytes from a region of size 32 [-Wstringop-overflow=]
```
```
/home/mjo/work/bundles/fv3-bundle/fms/field_manager/field_manager.F90:1196:0:

 1196 |       val_name = val_name(2:length-1)
      | 
Warning: ‘__builtin_memmove’ reading 128 bytes from a region of size 127 [-Wstringop-overflow=]
```
