### PR TITLE
Revert #15 and refix to only add flags for gfortran>=10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,7 +308,7 @@ ecbuild_add_library( TARGET   fms
                     )
 ################################################################################
 
-if(CMAKE_Fortran_COMPILER_ID MATCHES GNU AND CMAKE_Fortran_COMPILER VERSION_GREATER_EQUAL 10)
+if(CMAKE_Fortran_COMPILER_ID MATCHES GNU AND CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
     target_compile_options(${PROJECT_NAME} PRIVATE -fallow-invalid-boz -fallow-argument-mismatch)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,6 +308,10 @@ ecbuild_add_library( TARGET   fms
                     )
 ################################################################################
 
+if(CMAKE_Fortran_COMPILER_ID MATCHES GNU AND CMAKE_Fortran_COMPILER VERSION_GREATER_EQUAL 10)
+    target_compile_options(${PROJECT_NAME} PRIVATE -fallow-invalid-boz -fallow-argument-mismatch)
+endif()
+
 # glibc>=2.30 includes gettid in unistd.h if _GNU_SOURCE is set
 include(CheckSymbolExists)
 set(CMAKE_REQUIRED_DEFINITIONS "-D_GNU_SOURCE=1")

--- a/cmake/compiler_flags_GNU_Fortran.cmake
+++ b/cmake/compiler_flags_GNU_Fortran.cmake
@@ -7,7 +7,7 @@
 # FLAGS COMMON TO ALL BUILD TYPES
 ####################################################################
 
-set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-invalid-boz -fallow-argument-mismatch -fdefault-real-8 -fdefault-double-8 -fcray-pointer -fconvert=big-endian -ffree-line-length-none -fno-range-check -fbacktrace")
+set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fdefault-real-8 -fdefault-double-8 -fcray-pointer -fconvert=big-endian -ffree-line-length-none -fno-range-check -fbacktrace")
 
 ####################################################################
 # RELEASE FLAGS

--- a/cmake/compiler_flags_GNU_Fortran.cmake
+++ b/cmake/compiler_flags_GNU_Fortran.cmake
@@ -7,7 +7,7 @@
 # FLAGS COMMON TO ALL BUILD TYPES
 ####################################################################
 
-set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fdefault-real-8 -fdefault-double-8 -fcray-pointer -fconvert=big-endian -ffree-line-length-none -fno-range-check -fbacktrace")
+set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-invalid-boz -fallow-argument-mismatch -fdefault-real-8 -fdefault-double-8 -fcray-pointer -fconvert=big-endian -ffree-line-length-none -fno-range-check -fbacktrace")
 
 ####################################################################
 # RELEASE FLAGS


### PR DESCRIPTION
This fix will Revert #15 and only add the necessary flags for `gfortran>=10`