### PR TITLE
Fix GFortran-10 specific flags leaking to non-fortran compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,7 +338,8 @@ ecbuild_add_library( TARGET   fms
 ################################################################################
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES GNU AND CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
-    target_compile_options(${PROJECT_NAME} PRIVATE -fallow-invalid-boz -fallow-argument-mismatch)
+    target_compile_options(${PROJECT_NAME} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:-fallow-invalid-boz>
+                                                   $<$<COMPILE_LANGUAGE:Fortran>:-fallow-argument-mismatch>)
 endif()
 
 # glibc>=2.30 includes gettid in unistd.h if _GNU_SOURCE is set


### PR DESCRIPTION
**Description**
Fix GFortran-10 specific flags leaking to non-fortran compilers

Fixes # (issue)

Fix build errors reported as clang unknown compiler flag "-fallow-argument-mismatch".  This flag is not ment for clang but only GFortran.

**How Has This Been Tested?**
Build on OSX 10.15.6 with GCC 10 via homebrew and clang-gfortran-mpich JEDI-stack toolchain
