### PR TITLE
use GFS_PHYS compiler definition

### DIFF
--- a/cmake/fms_compiler_flags.cmake
+++ b/cmake/fms_compiler_flags.cmake
@@ -6,7 +6,7 @@
 
 # Standard FMS compiler definitions
 # ---------------------------------
-add_definitions( -Duse_libMPI -DSPMD -Duse_netCDF -Duse_LARGEFILE )
+add_definitions( -Duse_libMPI -DSPMD -Duse_netCDF -Duse_LARGEFILE -DGFS_PHYS )
 
 # Special cases
 # -------------


### PR DESCRIPTION
In order to reproduce some of the testing that is done with the GFS model we need to have the GFS_PHYS compiler definition to be reproducible.

This may change the results in soca, as it does with fv3-jedi but the results should be closer to if using MOM6 from the UFS models.