### PR TITLE
support for NVHPC compilers

### DIFF
--- a/cmake/fms_compiler_flags.cmake
+++ b/cmake/fms_compiler_flags.cmake
@@ -49,6 +49,10 @@ if (FV3LM_PRECISION MATCHES "DOUBLE" OR NOT FV3LM_PRECISION)
 
     set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -r8")
 
+  elseif( CMAKE_Fortran_COMPILER_ID MATCHES "NVHPC" )
+
+    set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -r8")
+
   elseif( CMAKE_Fortran_COMPILER_ID MATCHES "XL" )
 
     set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qdpc")


### PR DESCRIPTION
**Description**

NVIDIA recently acquired the compilers from PGI and changed the compiler id in cmake. I find this is necessary to get FMS to compile with the latest NVIDIA/PGI compiler suite, distributed within the NVIDIA HPC SDK 21.5.

Fixes # (issue)

**How Has This Been Tested?**

Tested on AWS with NVIDIA SDK 21.5

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

