### PR TITLE
release-stable: add option to compile without OpenMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@
 cmake_minimum_required( VERSION 3.12 )
 project( fms VERSION 2020.4.0 LANGUAGES C Fortran )
 
+option(OPENMP    "Build FMS with OpenMP support" OFF)
+
 ## Ecbuild integration
 find_package( ecbuild 3.3.2 REQUIRED )
 include( ecbuild_system NO_POLICY_SCOPE )
@@ -25,7 +27,9 @@ include( fms_compiler_flags )
 
 find_package( jedicmake QUIET)
 find_package( MPI REQUIRED COMPONENTS C Fortran )
-find_package( OpenMP COMPONENTS C Fortran )
+if(OPENMP)
+  find_package(OpenMP REQUIRED COMPONENTS C Fortran)
+endif()
 find_package( NetCDF REQUIRED COMPONENTS Fortran )
 
 ################################################################################
@@ -254,7 +258,9 @@ ecbuild_add_library( TARGET   fms
 # Link dependencies
 target_link_libraries( fms PUBLIC NetCDF::NetCDF_Fortran )
 target_link_libraries( fms PUBLIC MPI::MPI_Fortran )
-target_link_libraries( fms PUBLIC OpenMP::OpenMP_C OpenMP::OpenMP_Fortran )
+if(OPENMP)
+  target_link_libraries( fms PUBLIC OpenMP::OpenMP_C OpenMP::OpenMP_Fortran )
+endif()
 
 ################################################################################
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 cmake_minimum_required( VERSION 3.12 )
 project( fms VERSION 2020.4.0 LANGUAGES C Fortran )
 
-option(OPENMP "Build FMS with OpenMP support" OFF)
+option(OPENMP "Build FMS with OpenMP support" ON)
 
 ## Ecbuild integration
 find_package( ecbuild 3.3.2 REQUIRED )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 cmake_minimum_required( VERSION 3.12 )
 project( fms VERSION 2020.4.0 LANGUAGES C Fortran )
 
-option(OPENMP    "Build FMS with OpenMP support" OFF)
+option(OPENMP "Build FMS with OpenMP support" OFF)
 
 ## Ecbuild integration
 find_package( ecbuild 3.3.2 REQUIRED )

--- a/fms-import.cmake.in
+++ b/fms-import.cmake.in
@@ -11,8 +11,10 @@ if(NOT MPI_Fortran_FOUND)
     find_package( MPI REQUIRED COMPONENTS Fortran )
 endif()
 
-if(NOT OpenMP_Fortran_FOUND OR NOT OpenMP_C_FOUND )
-    find_package( OpenMP REQUIRED COMPONENTS C Fortran )
+if(@OPENMP@)
+    if(NOT OpenMP_Fortran_FOUND OR NOT OpenMP_C_FOUND )
+        find_package( OpenMP REQUIRED COMPONENTS C Fortran )
+    endif()
 endif()
 
 #Export Fortran compiler version for checking module compatibility


### PR DESCRIPTION
**Description**

Add option to compile the release-stable branch without OpenMP. This is required when compiling with the native clang compiler on macOS, because there is no OpenMP support. We shouldn't require users to install OpenMP support via homebrew, and having an option to compile without OpenMP can be useful for debugging on other systems, too, even if they have C/C++ OpenMP support.

Note. This PR is for the release-stable branch. Other branches like dev-jcsda don't need it, because their CMake build system that came from GFDL already has the option to compile without OpenMP. When/if release-stable is updated with changes in the authoritative repositories, many of the CMake build changes that were made in release-stable will no longer be required or invalid and will have to be removed.

Fixes no GitHub issue because the issue page is not available in JCSDA/FMS. However, it fixes the issue that one cannot compile the release-stable branch on systems that do not support OpenMP.

Similar changes will need to be made in many of the JCSDA packages so that a clean build without OpenMP is possible. Note that the default is to keep OpenMP on, i.e. nothing changes unless someone explicitly tells cmake to turn off OpenMP.

**How Has This Been Tested?**
Tested on macOS with clang 13.0.0 + gfortran 11.2.0.

**Checklist:**
- [x] My code follows the style guidelines of this project - I think so
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

